### PR TITLE
handle missing required arguments

### DIFF
--- a/src/QueryComplexity.js
+++ b/src/QueryComplexity.js
@@ -138,7 +138,12 @@ export default class QueryComplexity {
               const fieldType = getNamedType(field.type);
               
               // Get arguments
-              const args = getArgumentValues(field, childNode, this.options.variables || {});
+              let args;
+              try {
+                args = getArgumentValues(field, childNode, this.options.variables || {});
+              } catch (e) {
+                return this.context.reportError(e);
+              }
               
               // Check if we have child complexity
               let childComplexity = 0;

--- a/src/__tests__/QueryComplexity-test.js
+++ b/src/__tests__/QueryComplexity-test.js
@@ -223,4 +223,19 @@ describe('QueryComplexity analysis', () => {
     visit(ast, visitWithTypeInfo(typeInfo, visitor));
     expect(visitor.complexity).to.equal(1);
   });
+
+  it('should error on a missing non-null argument', () => {
+    const ast = parse(`
+        query {
+            requiredArgs(notcount: 0)
+        }
+      `);
+    const context = new ValidationContext(schema, ast, typeInfo);
+    const visitor = new ComplexityVisitor(context, {
+      maximumComplexity: 100
+    });
+    visit(ast, visitWithTypeInfo(typeInfo, visitor));
+    expect(context.getErrors().length).to.equal(1);
+    expect(context.getErrors()[0].message).to.equal('Argument "count" of required type "Int!" was not provided.');
+  });
 });

--- a/src/__tests__/fixtures/schema.js
+++ b/src/__tests__/fixtures/schema.js
@@ -119,6 +119,14 @@ const Query = new GraphQLObjectType({
       type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(Item))),
       resolve: () => [],
     },
+    requiredArgs: {
+      type: Item,
+      args: {
+        count: {
+          type: new GraphQLNonNull(GraphQLInt)
+        }
+      }
+    }
   }),
 });
 


### PR DESCRIPTION
Currently, if your schema has a required (non-null) argument, `getArgumentValues` will throw. As a result, the expected graphql response json is not created and the thrown error text is returned directly. This change handles that error as expected, and includes a test case.